### PR TITLE
bump ubi8 go image to 1.23

### DIFF
--- a/osl-operator-image/logic-rhel8-operator-image.yaml
+++ b/osl-operator-image/logic-rhel8-operator-image.yaml
@@ -15,7 +15,7 @@
 - schema_version: 1
   name: "operator-builder"
   version: "1.36.0"
-  from: "registry.access.redhat.com/ubi8/go-toolset:1.22"
+  from: "registry.access.redhat.com/ubi8/go-toolset:1.23"
   description: "Golang builder image for the Red Hat OpenShift Serverless Logic Operator"
 
   modules:


### PR DESCRIPTION
kubesmarts/kie-tools#105

bump to https://catalog.redhat.com/software/containers/rhel8/go-toolset/5b9c810add19c70b45cbd666

I’m checking whether this release includes the fix for https://github.com/golang/go/issues/72010, since that vulnerability was addressed in 1.23.8. However, Red Hat states: “This image does not have any unapplied Critical or Important security updates