### PR TITLE
[SRVLOGIC-598] - Fix CGO_ENABLED to enable manager to be a static linked binary

### DIFF
--- a/osl-operator-image/modules/com.redhat.osl.builder/install.sh
+++ b/osl-operator-image/modules/com.redhat.osl.builder/install.sh
@@ -18,5 +18,5 @@
 set -e
 
 cd $REMOTE_SOURCE_DIR/app/packages/sonataflow-operator
-source $CACHITO_ENV_FILE && go build -trimpath -ldflags=-buildid= -a -o manager cmd/main.go
+source $CACHITO_ENV_FILE && CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -a -o manager cmd/main.go
 mkdir /workspace && cp $REMOTE_SOURCE_DIR/app/packages/sonataflow-operator/manager /workspace


### PR DESCRIPTION
@saumya1singh please build this image on your end and run:

```shell
docker run -it --name test-operator <operator_image_tag> /bin/sh
```

Once inside the container:

```shell
ldd /usr/local/bin/manager
```

The output should be:

```
not a dynamic executable
```

See https://issues.redhat.com/browse/SRVLOGIC-598