### PR TITLE
[9.103.x-prod] SRVLOGIC-598:Fix CGO_ENABLED to enable manager to be a static linked binary 

### DIFF
--- a/osl-operator-image/modules/com.redhat.osl.builder/install.sh
+++ b/osl-operator-image/modules/com.redhat.osl.builder/install.sh
@@ -18,5 +18,5 @@
 set -e
 
 cd $REMOTE_SOURCE_DIR/app/packages/sonataflow-operator
-source $CACHITO_ENV_FILE && go build -trimpath -ldflags=-buildid= -a -o manager cmd/main.go
+source $CACHITO_ENV_FILE && CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -a -o manager cmd/main.go
 mkdir /workspace && cp $REMOTE_SOURCE_DIR/app/packages/sonataflow-operator/manager /workspace


### PR DESCRIPTION
…ked binary

cherry-picks https://github.com/kubesmarts/osl-images/pull/15 to `9.103.x-prod`