### PR TITLE
BAQE-3160: Fix OSL product nightly - cleanup main branch

### DIFF
--- a/osl-cli-artifacts-image/logic-kn-workflow-cli-artifacts-rhel8-image.yaml
+++ b/osl-cli-artifacts-image/logic-kn-workflow-cli-artifacts-rhel8-image.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 - name: "packager"
-  version: "1.35.0"
+  version: "999.0.0.main"
   from: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
   modules:
     repositories:
@@ -22,7 +22,7 @@
       - name: com.redhat.osl.cli.packager
 
 - name: "openshift-serverless-1/logic-kn-workflow-cli-artifacts-rhel8"
-  version: "1.35.0"
+  version: "999.0.0.main"
   description: "Red Hat OpenShift Serverless Logic 1 kn-workflow CLI artifacts"
   from: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
   labels:
@@ -31,7 +31,7 @@
     - name: name
       value: "openshift-serverless-1/kn-workflow-cli-artifacts-rhel8"
     - name: version
-      value: "1.35.0"
+      value: "999.0.0.main"
     - name: summary
       value: "Red Hat OpenShift Serverless Logic 1 kn-workflow CLI artifacts"
     - name: description
@@ -67,4 +67,4 @@
           pulp_repos: true
     repository:
       name: containers/openshift-serverless-1-logic-kn-workflow-cli-artifacts
-      branch: openshift-serverless-1.35-rhel-8
+      branch: openshift-serverless-999.0.0.main-rhel-8

--- a/osl-cli-artifacts-image/modules/com.redhat.osl.cli.artifacts/module.yaml
+++ b/osl-cli-artifacts-image/modules/com.redhat.osl.cli.artifacts/module.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: "com.redhat.osl.cli.artifacts"
-version: "1.35.0"
+version: "999.0.0.main"
 description: "Copy binaries from the packager image"
 
 execute:

--- a/osl-cli-artifacts-image/modules/com.redhat.osl.cli.packager/module.yaml
+++ b/osl-cli-artifacts-image/modules/com.redhat.osl.cli.packager/module.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: "com.redhat.osl.cli.packager"
-version: "1.35.0"
+version: "999.0.0.main"
 description: "Download kn-workflow cli binaries from a given repository"
 
 packages:

--- a/osl-operator-image/logic-rhel8-operator-image.yaml
+++ b/osl-operator-image/logic-rhel8-operator-image.yaml
@@ -14,7 +14,7 @@
 
 - schema_version: 1
   name: "operator-builder"
-  version: "1.35.0"
+  version: "999.0.0.main"
   from: "registry.access.redhat.com/ubi8/go-toolset:1.23"
   description: "Golang builder image for the Red Hat OpenShift Serverless Logic Operator"
 
@@ -43,7 +43,7 @@
             - aarch64
 
 - name: "openshift-serverless-1/logic-rhel8-operator"
-  version: "1.35.0"
+  version: "999.0.0.main"
   from: "registry.access.redhat.com/ubi8/ubi-micro:latest"
   description: "Runtime Image for the Red Hat OpenShift Serverless Logic Operator"
 

--- a/osl-operator-image/modules/com.redhat.osl.builder/module.yaml
+++ b/osl-operator-image/modules/com.redhat.osl.builder/module.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: com.redhat.osl.builder
-version: "1.35.0"
+version: "999.0.0.main"
 description: Builds the operator binary
 
 envs:


### PR DESCRIPTION
Cleans osl-images main branch product version references so it is not confusing and we retain some common versioning across our midstream.

Will use `999.0.0.main` for the osl-images manifests for now. Can be later used to have nice branching jobs that will update this version to product version.