### PR TITLE
SRVLOGIC-608 OSL Builder image always downloads plexus-utils-1.1

### DIFF
--- a/apps-maven-builder/build-quarkus-app.sh
+++ b/apps-maven-builder/build-quarkus-app.sh
@@ -58,8 +58,7 @@ case ${image_name} in
     "osl-swf-builder")
         quarkus_extensions="${quarkus_extensions},${osl_swf_builder_extensions},${quarkus_extensions_extra_deps}"
         # additional libraries not meant to be added to pom.xml
-        # Plexus-Utils 1.1 should be banned from the image. We can safely remove it once we upgrade to Maven 3.9.x: https://issues.apache.org/jira/browse/MNG-6965
-        osl_swf_builder_additional_libs="org.kie:kie-addons-quarkus-persistence-jdbc:${kogito_version},org.kie:kie-addons-quarkus-persistence-jdbc-deployment:${kogito_version},io.quarkus:quarkus-jdbc-postgresql:${quarkus_version},io.quarkus:quarkus-jdbc-postgresql-deployment:${quarkus_version},org.codehaus.plexus:plexus-utils:1.1"
+        osl_swf_builder_additional_libs="org.kie:kie-addons-quarkus-persistence-jdbc:${kogito_version},org.kie:kie-addons-quarkus-persistence-jdbc-deployment:${kogito_version},io.quarkus:quarkus-jdbc-postgresql:${quarkus_version},io.quarkus:quarkus-jdbc-postgresql-deployment:${quarkus_version}"
         ;;
     "osl-swf-devmode")
         quarkus_extensions="${quarkus_extensions},${osl_swf_devmode_extensions},${quarkus_extensions_extra_deps}"


### PR DESCRIPTION
    - Remove the workaround that added org.codehaus.plexus:plexus-utils:1.1 as dependency since the original problem in maven is already solved in maven 3.9.9