### PR TITLE
[9.105.x-prod] SRVLOGIC-934 - Fix version values in prod branch

### DIFF
--- a/images-dist/logic-data-index-ephemeral-rhel9-image.yaml
+++ b/images-dist/logic-data-index-ephemeral-rhel9-image.yaml
@@ -19,7 +19,7 @@
 schema_version: 1
 
 name: "openshift-serverless-1/logic-data-index-ephemeral-rhel9"
-version: "main"
+version: "1.38.0"
 from: "registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24"
 description: "Red Hat build of Runtime image for Kogito Data Index Service for ephemeral PostgreSQL persistence provider"
 

--- a/images-dist/logic-data-index-ephemeral-rhel9-image.yaml
+++ b/images-dist/logic-data-index-ephemeral-rhel9-image.yaml
@@ -37,7 +37,7 @@ labels:
   - name: "io.openshift.expose-services"
     value: "8080:http"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
 
 envs:
   - name: "SCRIPT_DEBUG"

--- a/images-dist/logic-data-index-postgresql-rhel9-image.yaml
+++ b/images-dist/logic-data-index-postgresql-rhel9-image.yaml
@@ -37,7 +37,7 @@ labels:
   - name: "io.openshift.expose-services"
     value: "8080:http"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
 
 envs:
   - name: "SCRIPT_DEBUG"

--- a/images-dist/logic-data-index-postgresql-rhel9-image.yaml
+++ b/images-dist/logic-data-index-postgresql-rhel9-image.yaml
@@ -19,7 +19,7 @@
 schema_version: 1
 
 name: "openshift-serverless-1/logic-data-index-postgresql-rhel9"
-version: "main"
+version: "1.38.0"
 from: "registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24"
 description: "Red Hat build of Runtime image for Kogito Data Index Service for PostgreSQL persistence provider"
 

--- a/images-dist/logic-db-migrator-tool-rhel9-image.yaml
+++ b/images-dist/logic-db-migrator-tool-rhel9-image.yaml
@@ -19,7 +19,7 @@
 schema_version: 1
 
 name: "openshift-serverless-1/logic-db-migrator-tool-rhel9"
-version: "main"
+version: "1.38.0"
 from: "registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24"
 description: "Red Hat build of Runtime image for Kogito DB Migrator Tool"
 

--- a/images-dist/logic-db-migrator-tool-rhel9-image.yaml
+++ b/images-dist/logic-db-migrator-tool-rhel9-image.yaml
@@ -37,7 +37,7 @@ labels:
   - name: "io.openshift.expose-services"
     value: "8080:http"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
 
 envs:
   - name: "SCRIPT_DEBUG"

--- a/images-dist/logic-jobs-service-ephemeral-rhel9-image.yaml
+++ b/images-dist/logic-jobs-service-ephemeral-rhel9-image.yaml
@@ -19,7 +19,7 @@
 schema_version: 1
 
 name: "openshift-serverless-1/logic-jobs-service-ephemeral-rhel9"
-version: "main"
+version: "1.38.0"
 from: "registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24"
 description: "Red Hat build of Runtime image for Kogito in memory Jobs Service"
 

--- a/images-dist/logic-jobs-service-ephemeral-rhel9-image.yaml
+++ b/images-dist/logic-jobs-service-ephemeral-rhel9-image.yaml
@@ -37,7 +37,7 @@ labels:
   - name: "io.openshift.expose-services"
     value: "8080:http"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
 
 envs:
   - name: "SCRIPT_DEBUG"

--- a/images-dist/logic-jobs-service-postgresql-rhel9-image.yaml
+++ b/images-dist/logic-jobs-service-postgresql-rhel9-image.yaml
@@ -37,7 +37,7 @@ labels:
   - name: "io.openshift.expose-services"
     value: "8080:http"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
 
 envs:
   - name: "SCRIPT_DEBUG"

--- a/images-dist/logic-jobs-service-postgresql-rhel9-image.yaml
+++ b/images-dist/logic-jobs-service-postgresql-rhel9-image.yaml
@@ -19,7 +19,7 @@
 schema_version: 1
 
 name: "openshift-serverless-1/logic-jobs-service-postgresql-rhel9"
-version: "main"
+version: "1.38.0"
 from: "registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24"
 description: "Red Hat build of Runtime image for Kogito Jobs Service based on Postgresql"
 

--- a/images-dist/logic-management-console-rhel9-image.yaml
+++ b/images-dist/logic-management-console-rhel9-image.yaml
@@ -18,7 +18,7 @@
 #
 name: "openshift-serverless-1/logic-management-console-rhel9"
 from: "registry.access.redhat.com/ubi9/httpd-24:latest"
-version: "main"
+version: "1.38.0"
 description: "OpenShift Serverless Logic Management Console Image"
 
 labels:

--- a/images-dist/logic-management-console-rhel9-image.yaml
+++ b/images-dist/logic-management-console-rhel9-image.yaml
@@ -23,7 +23,7 @@ description: "OpenShift Serverless Logic Management Console Image"
 
 labels:
   - name: "io.quarkus.platform.version"
-    value: "3.27.2"
+    value: "3.27.2.redhat-00002"
   - name: "org.kie.kogito.version"
     value: "9.105.0"
   - name: "maintainer"

--- a/images-dist/logic-management-console-rhel9-image.yaml
+++ b/images-dist/logic-management-console-rhel9-image.yaml
@@ -25,7 +25,7 @@ labels:
   - name: "io.quarkus.platform.version"
     value: "3.27.2"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
   - name: "maintainer"
     value: "Red Hat <serverless-logic-team@redhat.com>"
   - name: "io.k8s.description"

--- a/images-dist/logic-operator-bundle-image.yaml
+++ b/images-dist/logic-operator-bundle-image.yaml
@@ -15,7 +15,7 @@
 schema_version: 1
 name: "openshift-serverless-1/logic-operator-bundle"
 description: "OpenShift Serverless Logic Operator Bundle"
-version: "main"
+version: "1.38.0"
 from: "scratch"
 
 labels:

--- a/images-dist/logic-swf-builder-rhel9-image.yaml
+++ b/images-dist/logic-swf-builder-rhel9-image.yaml
@@ -28,7 +28,7 @@ labels:
   - name: "io.openshift.s2i.destination"
     value: "/tmp"
   - name: "io.quarkus.platform.version"
-    value: "3.27.2"
+    value: "3.27.2.redhat-00002"
   - name: "org.kie.kogito.version"
     value: "9.105.0"
   - name: "com.redhat.component"

--- a/images-dist/logic-swf-builder-rhel9-image.yaml
+++ b/images-dist/logic-swf-builder-rhel9-image.yaml
@@ -30,7 +30,7 @@ labels:
   - name: "io.quarkus.platform.version"
     value: "3.27.2"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
   - name: "com.redhat.component"
     value: "openshift-serverless-1-logic-swf-builder-rhel9-container"
   - name: "maintainer"

--- a/images-dist/logic-swf-builder-rhel9-image.yaml
+++ b/images-dist/logic-swf-builder-rhel9-image.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: "openshift-serverless-1/logic-swf-builder-rhel9"
-version: "main"
+version: "1.38.0"
 from: "registry.access.redhat.com/ubi9/openjdk-17:1.24"
 description: "Red Hat build of Runtime image for Kogito Serverless Workflow builder with Quarkus extensions libraries preinstalled"
 

--- a/images-dist/logic-swf-devmode-rhel9-image.yaml
+++ b/images-dist/logic-swf-devmode-rhel9-image.yaml
@@ -19,7 +19,7 @@
 schema_version: 1
 name: "openshift-serverless-1/logic-swf-devmode-rhel9"
 from: "registry.access.redhat.com/ubi9/openjdk-17:1.24"
-version: "main"
+version: "1.38.0"
 description: "Red Hat build of Kogito Serverless Workflow development mode image with Quarkus extensions libraries preinstalled"
 
 labels:

--- a/images-dist/logic-swf-devmode-rhel9-image.yaml
+++ b/images-dist/logic-swf-devmode-rhel9-image.yaml
@@ -24,7 +24,7 @@ description: "Red Hat build of Kogito Serverless Workflow development mode image
 
 labels:
   - name: "io.quarkus.platform.version"
-    value: "3.27.2"
+    value: "3.27.2.redhat-00002"
   - name: "org.kie.kogito.version"
     value: "9.105.0"
   - name: "io.k8s.description"

--- a/images-dist/logic-swf-devmode-rhel9-image.yaml
+++ b/images-dist/logic-swf-devmode-rhel9-image.yaml
@@ -26,7 +26,7 @@ labels:
   - name: "io.quarkus.platform.version"
     value: "3.27.2"
   - name: "org.kie.kogito.version"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
   - name: "io.k8s.description"
     value: "Red Hat build of Kogito Serverless Workflow development mode image with Quarkus extensions libraries preinstalled."
   - name: "io.k8s.display-name"

--- a/images-dist/modules/com.redhat.osl.bundleinstall/module.yaml
+++ b/images-dist/modules/com.redhat.osl.bundleinstall/module.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: com.redhat.osl.bundleinstall
-version: "main"
+version: "1.38.0"
 description: Copy the bund files to the target image
 
 artifacts:

--- a/images-dist/modules/image-dependencies/module.yaml
+++ b/images-dist/modules/image-dependencies/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.image.dependencies
-version: "main"
+version: "1.38.0"
 description: holds common dependencies across images
 
 execute:

--- a/images-dist/modules/kogito-custom-truststore/module.yaml
+++ b/images-dist/modules/kogito-custom-truststore/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.security.custom.truststores
-version: "main"
+version: "1.38.0"
 description: "Adds the capability of configuring a custom Java Truststore to replace the original cacerts"
 
 envs:

--- a/images-dist/modules/kogito-data-index-common/module.yaml
+++ b/images-dist/modules/kogito-data-index-common/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.dataindex.common
-version: "main"
+version: "1.38.0"
 description: "Common modules for data-index persistence provider images, any addition that is common must be added in this module"
 
 envs:

--- a/images-dist/modules/kogito-dynamic-resources/module.yaml
+++ b/images-dist/modules/kogito-dynamic-resources/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.dynamic.resources
-version: "main"
+version: "1.38.0"
 
 description: -| Module retrieved from https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/java/jvm/bash However it contains a few customizations to fit Kogito needs.
 

--- a/images-dist/modules/kogito-jobs-service-common/module.yaml
+++ b/images-dist/modules/kogito-jobs-service-common/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.jobs.service.common
-version: "main"
+version: "1.38.0"
 description: "This module needs to be run last, if adding it, add in the last position."
 
 envs:

--- a/images-dist/modules/kogito-launch-scripts/module.yaml
+++ b/images-dist/modules/kogito-launch-scripts/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.launch.scripts
-version: "main"
+version: "1.38.0"
 
 execute:
   - script: configure

--- a/images-dist/modules/kogito-logging/module.yaml
+++ b/images-dist/modules/kogito-logging/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.logging
-version: "main"
+version: "1.38.0"
 
 execute:
   - script: configure

--- a/images-dist/modules/kogito-maven/common/module.yaml
+++ b/images-dist/modules/kogito-maven/common/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.maven.common
-version: "main"
+version: "1.38.0"
 
 envs:
   - name: "MAVEN_HOME"

--- a/images-dist/modules/kogito-project-versions/module.yaml
+++ b/images-dist/modules/kogito-project-versions/module.yaml
@@ -28,10 +28,10 @@ envs:
     value: "com.redhat.quarkus.platform"
     description: Defines the Quarkus Platform groupId to be used by the builder images. Not intended to be changed by end user.
   - name: "QUARKUS_PLATFORM_VERSION"
-    value: "3.27.2"
+    value: "3.27.2.redhat-00002"
     description: Defines the Quarkus Platform version to be used by the builder images. Not intended to be changed by end user.
   - name: "QUARKUS_VERSION"
-    value: "3.27.2"
+    value: "3.27.2.redhat-00001"
     description: Defines the Quarkus version to be used by the builder images dependencies in cases where QUARKUS_PLATFORM_VERSION needs to be overridden. Not intended to be changed by end user.
   - name: "SONATAFLOW_QUARKUS_DEVUI_VERSION"
     value: "9.105.0"

--- a/images-dist/modules/kogito-project-versions/module.yaml
+++ b/images-dist/modules/kogito-project-versions/module.yaml
@@ -22,7 +22,7 @@ version: "9.105.0"
 description: "Kogito Project versions information"
 envs:
   - name: "KOGITO_VERSION"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
     description: Defines the Kogito version to be used by the builder images. Not intended to be changed by end user.
   - name: "QUARKUS_PLATFORM_GROUPID"
     value: "com.redhat.quarkus.platform"
@@ -34,5 +34,5 @@ envs:
     value: "3.27.2"
     description: Defines the Quarkus version to be used by the builder images dependencies in cases where QUARKUS_PLATFORM_VERSION needs to be overridden. Not intended to be changed by end user.
   - name: "SONATAFLOW_QUARKUS_DEVUI_VERSION"
-    value: "999-SNAPSHOT"
+    value: "9.105.0"
     description: Defines the SonataFlow Quarkus Dev UI version to be used by the devmode image. Not intended to be changed by end user.

--- a/images-dist/modules/kogito-project-versions/module.yaml
+++ b/images-dist/modules/kogito-project-versions/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.project.versions
-version: "9.105.0"
+version: "1.38.0"
 description: "Kogito Project versions information"
 envs:
   - name: "KOGITO_VERSION"

--- a/images-dist/modules/kogito-system-user/module.yaml
+++ b/images-dist/modules/kogito-system-user/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.kogito.system.user
-version: "main"
+version: "1.38.0"
 
 execute:
   - script: add-user

--- a/images-dist/modules/maven-settings/module.yaml
+++ b/images-dist/modules/maven-settings/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.maven
-version: "main"
+version: "1.38.0"
 
 execute:
   - script: configure

--- a/images-dist/modules/osl-data-index-ephemeral/module.yaml
+++ b/images-dist/modules/osl-data-index-ephemeral/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.dataindex-ephemeral
-version: "main"
+version: "1.38.0"
 
 artifacts:
   - name: data-index-service-inmemory-image-build.zip

--- a/images-dist/modules/osl-data-index-postgresql/module.yaml
+++ b/images-dist/modules/osl-data-index-postgresql/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.dataindex-postgresql
-version: "main"
+version: "1.38.0"
 
 artifacts:
   - name: data-index-service-postgresql-image-build.zip

--- a/images-dist/modules/osl-db-migrator-tool/postgresql/module.yaml
+++ b/images-dist/modules/osl-db-migrator-tool/postgresql/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.db-migrator-tool
-version: "main"
+version: "1.38.0"
 
 artifacts:
   - name: db-migrator-tool-image-build.zip

--- a/images-dist/modules/osl-jobs-service-ephemeral/module.yaml
+++ b/images-dist/modules/osl-jobs-service-ephemeral/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.jobs-service-ephemeral
-version: "main"
+version: "1.38.0"
 
 artifacts:
   - name: jobs-service-inmemory-image-build.zip

--- a/images-dist/modules/osl-jobs-service-postgresql/module.yaml
+++ b/images-dist/modules/osl-jobs-service-postgresql/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.jobs-service-postgresql
-version: "main"
+version: "1.38.0"
 
 artifacts:
   - name: jobs-service-postgresql-image-build.zip

--- a/images-dist/modules/osl-management-console/module.yaml
+++ b/images-dist/modules/osl-management-console/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.management.console
-version: "main"
+version: "1.38.0"
 description: "OpenShift Serverless Management Console Image Configuration"
 
 execute:

--- a/images-dist/modules/osl-swf-builder-runtime/module.yaml
+++ b/images-dist/modules/osl-swf-builder-runtime/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.swf.builder.runtime
-version: "main"
+version: "1.38.0"
 description: "OpenShift Serverless Logic builder module with required extensions"
 
 artifacts:

--- a/images-dist/modules/osl-swf-devmode-runtime/module.yaml
+++ b/images-dist/modules/osl-swf-devmode-runtime/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.swf.devmode.runtime
-version: "main"
+version: "1.38.0"
 description: "OpenShift Serverless Logic devmode with required extensions"
 
 envs:

--- a/images-dist/modules/pkg-update/module.yaml
+++ b/images-dist/modules/pkg-update/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: com.redhat.osl.pkg-update
-version: "main"
+version: "1.38.0"
 description: "Perform a system update via the package manager."
 
 execute:

--- a/images-dist/modules/sonataflow/builder/runtime/module.yaml
+++ b/images-dist/modules/sonataflow/builder/runtime/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.sonataflow.builder.runtime
-version: "main"
+version: "1.38.0"
 description: "Apache KIE SonataFlow builder runtime module"
 
 execute:

--- a/images-dist/modules/sonataflow/common/build/module.yaml
+++ b/images-dist/modules/sonataflow/common/build/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.sonataflow.common.build
-version: "main"
+version: "1.38.0"
 description: "SonataFlow image build process"
 
 # Requires org.kie.sonataflow.common.scripts module

--- a/images-dist/modules/sonataflow/common/quarkus/registry/module.yaml
+++ b/images-dist/modules/sonataflow/common/quarkus/registry/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.sonataflow.common.quarkus.registry
-version: "main"
+version: "1.38.0"
 description: "SonataFlow Images Quarkus Registry Module"
 
 envs:

--- a/images-dist/modules/sonataflow/common/scripts/module.yaml
+++ b/images-dist/modules/sonataflow/common/scripts/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.sonataflow.common.scripts
-version: "main"
+version: "1.38.0"
 description: "SonataFlow images common scripts"
 
 envs:

--- a/images-dist/modules/sonataflow/devmode/runtime/common/module.yaml
+++ b/images-dist/modules/sonataflow/devmode/runtime/common/module.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 name: org.kie.sonataflow.devmode.runtime.common
-version: "main"
+version: "1.38.0"
 description: "Kogito Serverless Workflow devmode common module"
 
 execute:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/SRVLOGIC-934

This has 3 commits. 
Here is the reasoning and details for why I did them:

94921b97c850bdd9e93f14044c8aaafea0ad6fa7 - Updates version of manifests

All manifests must be updated for the release, previous release did this thanks to execution of osl_export_images workflow in kie-tools repository with adjsuted `.env` file. For 1.38.0  we discussed this can be done on the branch via the @jankrystof-ibm automation during the branch creation.


f0970adf2523a505b3b43a4acb8fc5f06419291a - updates of all `999-SNAPSHOT` values to the kogito placeholder version `9.105.0`

Looks like some gap in the automation. We should have everything on the branch using the placeholder. So that we can execute the replacement to redhat version of  Kogito Java runtimes without issues and have consistent result.

94921b97c850bdd9e93f14044c8aaafea0ad6fa7 - Quarkus version updates to redhat version

This is something that should be done the moment we know what redhat Quarkus version and Quarkus platformversions we are going to use. We did establish this before cut-off, so most likely should be also included in the cut-off automation.
Currently it is part of the product build document, but this steps was not done for `1.38.0`


Lastly, we are already done with PNC build, yet I do not see any PR that updates all `9.105.0` occurrences to the `9.105.0.redhat-00002`. I can already see we did execute a build of container images, but is this mandatory step is not done. 
I have double checked the product build document and it specifically mentions these steps. 
@saumya1singh  Why are the steps skipped? 