### PR TITLE
[SRVLOGIC-1044] Update go-toolset base image to 1.25 in operator image.

### DIFF
--- a/osl-operator-image/logic-rhel9-operator-image.yaml
+++ b/osl-operator-image/logic-rhel9-operator-image.yaml
@@ -15,7 +15,7 @@
 - schema_version: 1
   name: "operator-builder"
   version: "999.0.0.main"
-  from: "registry.access.redhat.com/ubi9/go-toolset:1.24"
+  from: "registry.access.redhat.com/ubi9/go-toolset:1.25"
   description: "Golang builder image for the Red Hat OpenShift Serverless Logic Operator"
 
   modules:


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1044

Updates the go-toolset version. 