### PR TITLE
[SRVLOGIC-1086] Update Quarkus to 3.27.4.1.

### DIFF
--- a/apps-maven-builder/pom.xml
+++ b/apps-maven-builder/pom.xml
@@ -26,9 +26,9 @@
         <build.quarkusapp.argument.imagename.devmode>osl-swf-devmode</build.quarkusapp.argument.imagename.devmode>
         <build.quarkusapp.argument.imagename.builder>osl-swf-builder</build.quarkusapp.argument.imagename.builder>
         <build.quarkusapp.argument.quarkusplatform.groupid>io.quarkus.platform</build.quarkusapp.argument.quarkusplatform.groupid>
-        <build.quarkusapp.argument.quarkusplatform.version>3.27.4</build.quarkusapp.argument.quarkusplatform.version>
+        <build.quarkusapp.argument.quarkusplatform.version>3.27.4.1</build.quarkusapp.argument.quarkusplatform.version>
         <!-- Quarkus version and Quarkus Platform version might be different due to rebuilds downstream -->
-        <build.quarkusapp.argument.quarkus.version>3.27.4</build.quarkusapp.argument.quarkus.version>
+        <build.quarkusapp.argument.quarkus.version>3.27.4.1</build.quarkusapp.argument.quarkus.version>
         <build.quarkusapp.argument.kogitoversion>111-SNAPSHOT</build.quarkusapp.argument.kogitoversion>
 
         <!-- Start of block of plugins and dependencies that will be given to build-quarkus-app.sh script-->

--- a/images-dist/logic-management-console-rhel9-image.yaml
+++ b/images-dist/logic-management-console-rhel9-image.yaml
@@ -23,7 +23,7 @@ description: "OpenShift Serverless Logic Management Console Image"
 
 labels:
   - name: "io.quarkus.platform.version"
-    value: "3.27.4"
+    value: "3.27.4.1"
   - name: "org.kie.kogito.version"
     value: "111-SNAPSHOT"
   - name: "maintainer"

--- a/images-dist/logic-swf-builder-rhel9-image.yaml
+++ b/images-dist/logic-swf-builder-rhel9-image.yaml
@@ -28,7 +28,7 @@ labels:
   - name: "io.openshift.s2i.destination"
     value: "/tmp"
   - name: "io.quarkus.platform.version"
-    value: "3.27.4"
+    value: "3.27.4.1"
   - name: "org.kie.kogito.version"
     value: "111-SNAPSHOT"
   - name: "com.redhat.component"

--- a/images-dist/logic-swf-devmode-rhel9-image.yaml
+++ b/images-dist/logic-swf-devmode-rhel9-image.yaml
@@ -24,7 +24,7 @@ description: "Red Hat build of Kogito Serverless Workflow development mode image
 
 labels:
   - name: "io.quarkus.platform.version"
-    value: "3.27.4"
+    value: "3.27.4.1"
   - name: "org.kie.kogito.version"
     value: "111-SNAPSHOT"
   - name: "io.k8s.description"

--- a/images-dist/modules/kogito-project-versions/module.yaml
+++ b/images-dist/modules/kogito-project-versions/module.yaml
@@ -29,7 +29,7 @@ envs:
     value: "io.quarkus.platform"
     description: Defines the Quarkus Platform groupId to be used by the builder images. Not intended to be changed by end user.
   - name: "QUARKUS_PLATFORM_VERSION"
-    value: "3.27.4"
+    value: "3.27.4.1"
     description: Defines the Quarkus Platform version to be used by the builder images. Not intended to be changed by end user.
   - name: "QUARKUS_VERSION"
     value: "### SET ME DURING BUILD PROCESS ###"


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1086

Updates Quarkus to 3.27.4.1 and aligns other dependencies with the changes in the new Quarkus version.